### PR TITLE
DATAINT-1770: Fix UDF Read Values

### DIFF
--- a/PluginAutotask/API/Read/ReadRecords.cs
+++ b/PluginAutotask/API/Read/ReadRecords.cs
@@ -125,7 +125,25 @@ namespace PluginAutotask.API.Read
 
         private static Record ConvertRawRecordToRecord(Dictionary<string, object> rawRecord, Schema schema)
         {
+            List<UserDefinedField> rawUDFs;
             var recordMap = new Dictionary<string, object?>();
+
+            try
+            {
+                if (rawRecord.ContainsKey("userDefinedFields"))
+                {
+                    rawUDFs = JsonConvert.DeserializeObject<List<UserDefinedField>>(JsonConvert.SerializeObject(rawRecord["userDefinedFields"]));
+
+                    foreach (var udf in rawUDFs)
+                    {
+                        rawRecord.TryAdd(udf.Name, udf.Value);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, $"Not able to parse UDFs");
+            }
 
             foreach (var property in schema.Properties)
             {

--- a/PluginAutotask/API/Utility/Constants.cs
+++ b/PluginAutotask/API/Utility/Constants.cs
@@ -6,7 +6,7 @@ namespace PluginAutotask.API.Utility
     public static class Constants
     {
         public static string TestConnectionPath = "Companies/0";
-        public static Query GetAllRecordsQuery = new Query() 
+        public static Query GetAllRecordsQuery = new Query()
         {
             Filter = new List<Filter>()
             {
@@ -19,7 +19,7 @@ namespace PluginAutotask.API.Utility
             }
         };
 
-        public static Query GetAllRecordsQueryTicketHistory = new Query() 
+        public static Query GetAllRecordsQueryTicketHistory = new Query()
         {
             Filter = new List<Filter>()
             {
@@ -105,6 +105,11 @@ namespace PluginAutotask.API.Utility
             "ServiceCallTicketResources",
             "ServiceCallTickets",
             "Skills",
+            // DATAINT-1770
+            "Companies",
+            "Contacts",
+            "Tasks",
+            "Projects",
         };
     }
 }

--- a/PluginAutotask/DataContracts/UserDefinedField.cs
+++ b/PluginAutotask/DataContracts/UserDefinedField.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PluginAutotask.DataContracts
+{
+    public class UserDefinedField
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("value")]
+        public object Value { get; set; }
+    }
+}


### PR DESCRIPTION
resolves DATAINT-1770

This fixes reads so that values for UDFs get populated correctly and also adds Companies, Contacts, Tasks, and Projects to the discovered schemas.